### PR TITLE
Use the correct index variable to access the trees array

### DIFF
--- a/forest/index.js
+++ b/forest/index.js
@@ -98,7 +98,7 @@ RandomForestClassifier.prototype = {
         for (var i=0; i < data.length ;i++) {
             var dec = [];
             for (var j=0; j < this.n_estimators; j++){
-                dec.push(trees[i].predict(data[i]));
+                dec.push(trees[j].predict(data[i]));
             }
             if (utils.GetType(dec[0]) == "string"){
                 probabilities[i] = utils.GetDominate(dec);


### PR DESCRIPTION
Currently the `i` variable is used to access the `trees` array instead of the `j` variable which fails in cases where the number of trees is inferior to the number of data points that predict is run on.