### PR TITLE
Fixed incorrect string/int/float detection on labels

### DIFF
--- a/utilities/index.js
+++ b/utilities/index.js
@@ -113,7 +113,7 @@ var RID = function(){
 };
 
 var GetType = function(input) {
-    var m = (/[\d]+(\.[\d]+)?/).exec(input);
+    var m = (/^[\d]+(\.[\d]+)?$/).exec(input);
     if (m) {
        // Check if there is a decimal place
         if (m[1]) {


### PR DESCRIPTION
Labels such as "mystring1234" or "1234mystring" were being incorrectly classified as integers. I've corrected the regex to make it insist whole string is a number.